### PR TITLE
Add Bluespec Codex setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# Bluespec Codex Environment
+
+This repository provides a simple setup script for building the open-source
+Bluespec toolchain (BSC) in an environment that Codex can use for
+building and testing Bluespec SystemVerilog (BSV) code.
+
+## Requirements
+
+- Ubuntu or Debian based Linux distribution
+- `apt-get` package manager
+- Internet access to fetch dependencies
+- Root privileges (or sudo) to install packages
+
+## Quick Start
+
+Run the setup script to install all dependencies and build BSC:
+
+```bash
+./scripts/setup_bsc.sh
+```
+
+The script will:
+
+1. Install the packages required to build the Bluespec compiler.
+2. Clone the BSC source repository.
+3. Build the compiler and install it under `/opt/bsc`.
+4. Add `/opt/bsc/bin` to your `PATH`.
+5. Run a simple smoke test (`make check-smoke`) to verify the build.
+
+After the script finishes, restart your shell or source your `.bashrc`
+so that the updated `PATH` is active.
+
+## Usage
+
+Once installed, you can invoke `bsc` and related tools directly. Example:
+
+```bash
+bsc -help
+```
+
+This environment is suitable for Codex automation or local development.

--- a/scripts/setup_bsc.sh
+++ b/scripts/setup_bsc.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -e
+
+# Install dependencies for building Bluespec Compiler
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    git build-essential ghc cabal-install \
+    libghc-regex-compat-dev libghc-syb-dev libghc-old-time-dev libghc-split-dev \
+    tcl-dev pkg-config autoconf gperf flex bison iverilog
+
+# Clone BSC source if not already present
+if [ ! -d /tmp/bsc ]; then
+    git clone --recursive https://github.com/B-Lang-org/bsc /tmp/bsc
+fi
+
+cd /tmp/bsc
+
+# Build and install BSC into /opt/bsc
+make install-src
+mkdir -p /opt
+mv inst /opt/bsc
+
+# Update PATH for current session and future logins
+export PATH=/opt/bsc/bin:$PATH
+echo 'export PATH=/opt/bsc/bin:$PATH' >> ~/.bashrc
+
+# Run a smoke test to verify the installation
+make check-smoke
+
+echo "BSC installed to /opt/bsc"


### PR DESCRIPTION
## Summary
- add README with instructions for building the Bluespec compiler
- add `scripts/setup_bsc.sh` to install dependencies and build BSC

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68447dc4e4cc8326a379ac0eb1365687