### PR TITLE
Install pre-built BSC release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bluespec Codex Environment
 
-This repository provides a simple setup script for building the open-source
+This repository provides a simple setup script for installing the open-source
 Bluespec toolchain (BSC) in an environment that Codex can use for
 building and testing Bluespec SystemVerilog (BSV) code.
 
@@ -13,7 +13,7 @@ building and testing Bluespec SystemVerilog (BSV) code.
 
 ## Quick Start
 
-Run the setup script to install all dependencies and build BSC:
+Run the setup script to download the latest binary release and install BSC:
 
 ```bash
 ./scripts/setup_bsc.sh
@@ -21,11 +21,12 @@ Run the setup script to install all dependencies and build BSC:
 
 The script will:
 
-1. Install the packages required to build the Bluespec compiler.
-2. Clone the BSC source repository.
-3. Build the compiler and install it under `/opt/bsc`.
+1. Install the runtime packages required by the Bluespec tools.
+2. Detect your distribution and download the matching pre-built release
+   from the BSC GitHub repository.
+3. Extract the package under `/opt/bsc`.
 4. Add `/opt/bsc/bin` to your `PATH`.
-5. Run a simple smoke test (`make check-smoke`) to verify the build.
+5. Run a simple `bsc -help` command to verify the installation.
 
 After the script finishes, restart your shell or source your `.bashrc`
 so that the updated `PATH` is active.

--- a/scripts/setup_bsc.sh
+++ b/scripts/setup_bsc.sh
@@ -1,30 +1,51 @@
 #!/usr/bin/env bash
 set -e
 
-# Install dependencies for building Bluespec Compiler
+# Install runtime dependencies
 apt-get update
-DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    git build-essential ghc cabal-install \
-    libghc-regex-compat-dev libghc-syb-dev libghc-old-time-dev libghc-split-dev \
-    tcl-dev pkg-config autoconf gperf flex bison iverilog
+DEBIAN_FRONTEND=noninteractive apt-get install -y curl tar iverilog
 
-# Clone BSC source if not already present
-if [ ! -d /tmp/bsc ]; then
-    git clone --recursive https://github.com/B-Lang-org/bsc /tmp/bsc
+# Determine distribution ID and version
+if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    DIST_ID=$ID
+    DIST_VERSION=$VERSION_ID
+else
+    echo "Unable to detect distribution" >&2
+    exit 1
 fi
 
-cd /tmp/bsc
+# Query latest release tag
+TAG=$(curl -s https://api.github.com/repos/B-Lang-org/bsc/releases/latest | grep tag_name | cut -d '"' -f4)
 
-# Build and install BSC into /opt/bsc
-make install-src
-mkdir -p /opt
-mv inst /opt/bsc
+# Fetch list of assets for the latest release
+ASSET_JSON=$(curl -s https://api.github.com/repos/B-Lang-org/bsc/releases/latest)
 
-# Update PATH for current session and future logins
+# Try to find a matching asset for the distro
+ASSET_URL=$(echo "$ASSET_JSON" | grep browser_download_url | grep "bsc-${TAG}-${DIST_ID}-${DIST_VERSION}" | head -n1 | cut -d '"' -f4)
+
+# Fallback: match without minor version
+if [ -z "$ASSET_URL" ]; then
+    SHORT_VERSION=${DIST_VERSION%%.*}
+    ASSET_URL=$(echo "$ASSET_JSON" | grep browser_download_url | grep "bsc-${TAG}-${DIST_ID}-${SHORT_VERSION}" | head -n1 | cut -d '"' -f4)
+fi
+
+if [ -z "$ASSET_URL" ]; then
+    echo "No binary release found for ${DIST_ID}-${DIST_VERSION}" >&2
+    exit 1
+fi
+
+# Download and extract to /opt/bsc
+TMP_TAR=/tmp/bsc.tar.gz
+curl -L "$ASSET_URL" -o "$TMP_TAR"
+mkdir -p /opt/bsc
+tar -xzf "$TMP_TAR" -C /opt/bsc --strip-components=1
+
+# Update PATH
 export PATH=/opt/bsc/bin:$PATH
 echo 'export PATH=/opt/bsc/bin:$PATH' >> ~/.bashrc
 
-# Run a smoke test to verify the installation
-make check-smoke
+# Verify installation
+bsc -help >/dev/null
 
 echo "BSC installed to /opt/bsc"


### PR DESCRIPTION
## Summary
- pull the latest BSC binary package for the detected distro
- install runtime dependencies only
- verify with `bsc -help`
- document binary install method in README

## Testing
- `bash scripts/setup_bsc.sh`
- `/opt/bsc/bin/bsc -help`

------
https://chatgpt.com/codex/tasks/task_e_6844849cb18083269369b88712362ca2