### PR TITLE
Add basic PTX builder and AXPY example

### DIFF
--- a/axpy_kernel.ptx
+++ b/axpy_kernel.ptx
@@ -1,0 +1,14 @@
+.version 8.7
+.target sm_80
+.address_size 64
+
+.visible .entry axpy_one(
+    .param .f32 a,
+    .param .f32 x,
+    .param .f32 y
+)
+{
+    .reg .f32 %f0, %f1, %f2;
+    mad.f32 %f2, %f0, %f1, %f2;
+    ret;
+}

--- a/examples/axpy_example.cpp
+++ b/examples/axpy_example.cpp
@@ -1,0 +1,39 @@
+#include <iostream>
+#include "../include/ptx_builder.h"
+
+// Build a simple AXPY kernel using the PTX builder API.
+// The kernel performs: y = a * x + y for a single element.
+// This example generates PTX text and prints it to stdout.
+
+std::string build_axpy_kernel() {
+    using namespace ptx;
+    Builder b;
+    Reg rA("%f0");
+    Reg rX("%f1");
+    Reg rY("%f2");
+
+    // rY = a * x + y
+    b.mad(rY, rA, rX, rY);
+    b.ret();
+
+    std::ostringstream oss;
+    oss << ".version 8.7\n";
+    oss << ".target sm_80\n";
+    oss << ".address_size 64\n\n";
+    oss << ".visible .entry axpy_one(\n";
+    oss << "    .param .f32 a,\n";
+    oss << "    .param .f32 x,\n";
+    oss << "    .param .f32 y\n";
+    oss << ")\n";
+    oss << "{\n";
+    oss << "    .reg .f32 %f0, %f1, %f2;\n";
+    oss << b.str();
+    oss << "}\n";
+    return oss.str();
+}
+
+int main() {
+    std::cout << build_axpy_kernel();
+    return 0;
+}
+

--- a/include/ptx_builder.h
+++ b/include/ptx_builder.h
@@ -1,0 +1,83 @@
+#ifndef PTX_BUILDER_H
+#define PTX_BUILDER_H
+
+#include <string>
+#include <vector>
+#include <sstream>
+
+namespace ptx {
+
+// Simple representation of a PTX register
+class Reg {
+    std::string name_;
+public:
+    explicit Reg(const std::string &name) : name_(name) {}
+    const std::string &name() const { return name_; }
+};
+
+// Helper class to build PTX instruction strings
+class Builder {
+    std::vector<std::string> lines_;
+public:
+    void add(const Reg &d, const Reg &a, const Reg &b, const std::string &t = "f32");
+    void mul(const Reg &d, const Reg &a, const Reg &b, const std::string &t = "f32");
+    void mad(const Reg &d, const Reg &a, const Reg &b, const Reg &c, const std::string &t = "f32");
+    void fma(const Reg &d, const Reg &a, const Reg &b, const Reg &c, const std::string &t = "f32");
+    void ld_global(const Reg &d, const Reg &addr, const std::string &t = "f32");
+    void st_global(const Reg &addr, const Reg &s, const std::string &t = "f32");
+    void mov(const Reg &d, const Reg &s, const std::string &t = "f32");
+    void ret();
+    std::string str() const;
+};
+
+inline void Builder::add(const Reg &d, const Reg &a, const Reg &b, const std::string &t)
+{
+    lines_.emplace_back("add." + t + " " + d.name() + ", " + a.name() + ", " + b.name() + ";");
+}
+
+inline void Builder::mul(const Reg &d, const Reg &a, const Reg &b, const std::string &t)
+{
+    lines_.emplace_back("mul." + t + " " + d.name() + ", " + a.name() + ", " + b.name() + ";");
+}
+
+inline void Builder::mad(const Reg &d, const Reg &a, const Reg &b, const Reg &c, const std::string &t)
+{
+    lines_.emplace_back("mad." + t + " " + d.name() + ", " + a.name() + ", " + b.name() + ", " + c.name() + ";");
+}
+
+inline void Builder::fma(const Reg &d, const Reg &a, const Reg &b, const Reg &c, const std::string &t)
+{
+    lines_.emplace_back("fma." + t + " " + d.name() + ", " + a.name() + ", " + b.name() + ", " + c.name() + ";");
+}
+
+inline void Builder::ld_global(const Reg &d, const Reg &addr, const std::string &t)
+{
+    lines_.emplace_back("ld.global." + t + " " + d.name() + ", [" + addr.name() + "];\n");
+}
+
+inline void Builder::st_global(const Reg &addr, const Reg &s, const std::string &t)
+{
+    lines_.emplace_back("st.global." + t + " [" + addr.name() + "], " + s.name() + ";");
+}
+
+inline void Builder::mov(const Reg &d, const Reg &s, const std::string &t)
+{
+    lines_.emplace_back("mov." + t + " " + d.name() + ", " + s.name() + ";");
+}
+
+inline void Builder::ret()
+{
+    lines_.emplace_back("ret;");
+}
+
+inline std::string Builder::str() const
+{
+    std::ostringstream oss;
+    for (const auto &l : lines_)
+        oss << "    " << l << '\n';
+    return oss.str();
+}
+
+} // namespace ptx
+
+#endif // PTX_BUILDER_H


### PR DESCRIPTION
## Summary
- add a simple header-only PTX instruction builder
- show usage in a small example that builds an AXPY kernel
- include the generated PTX code for reference

## Testing
- `g++ examples/axpy_example.cpp -std=c++17 -o axpy_example`
- `./axpy_example`

------
https://chatgpt.com/codex/tasks/task_e_6856d01812448326bcdd2e692562d055