### PR TITLE
Add C++ stubs for Llama tensor API

### DIFF
--- a/examples/llama_example.cpp
+++ b/examples/llama_example.cpp
@@ -1,0 +1,26 @@
+#include <iostream>
+#include "../include/llama_api.h"
+
+// Example routine showing how the tensor APIs could be used to run a Llama model
+// inference. The API functions themselves are not implemented.
+
+using namespace llama;
+
+int main() {
+    // Configure a tiny model for demonstration
+    ModelConfig cfg{ /*num_layers*/ 2, /*hidden_size*/ 8, /*vocab_size*/ 32000 };
+    Model model(cfg);
+    Tokenizer tokenizer;
+    InferenceSession session(model);
+
+    // Encode input text
+    std::vector<int> prompt = tokenizer.encode("Hello Llama");
+
+    // Generate output tokens
+    std::vector<int> output_tokens = session.generate(prompt, 16);
+
+    // Decode to string
+    std::string output = tokenizer.decode(output_tokens);
+    std::cout << output << std::endl;
+    return 0;
+}

--- a/include/llama_api.h
+++ b/include/llama_api.h
@@ -1,0 +1,43 @@
+#ifndef LLAMA_API_H
+#define LLAMA_API_H
+
+#include <string>
+#include <vector>
+#include "tensor_ops.h"
+
+namespace llama {
+
+using tensor::Tensor;
+
+struct ModelConfig {
+    int num_layers;
+    int hidden_size;
+    int vocab_size;
+};
+
+class Model {
+public:
+    explicit Model(const ModelConfig &config);
+
+    Tensor token_embedding;
+    Tensor output_weight;
+    std::vector<Tensor> layer_weights;
+};
+
+class Tokenizer {
+public:
+    std::vector<int> encode(const std::string &text) const;
+    std::string decode(const std::vector<int> &tokens) const;
+};
+
+class InferenceSession {
+public:
+    explicit InferenceSession(const Model &model);
+    std::vector<int> generate(const std::vector<int> &prompt, int max_tokens);
+private:
+    const Model &model_;
+};
+
+} // namespace llama
+
+#endif // LLAMA_API_H

--- a/include/tensor_ops.h
+++ b/include/tensor_ops.h
@@ -1,0 +1,44 @@
+#ifndef TENSOR_OPS_H
+#define TENSOR_OPS_H
+
+#include <cstddef>
+#include <vector>
+
+namespace tensor {
+
+enum class DataType {
+    F32,
+    F16,
+    I32,
+};
+
+class Tensor {
+public:
+    Tensor() = default;
+    Tensor(const std::vector<std::size_t> &shape, DataType type);
+
+    const std::vector<std::size_t> &shape() const;
+    DataType type() const;
+
+private:
+    std::vector<std::size_t> shape_;
+    DataType type_{DataType::F32};
+};
+
+inline Tensor::Tensor(const std::vector<std::size_t> &shape, DataType type)
+    : shape_(shape), type_(type) {}
+
+inline const std::vector<std::size_t> &Tensor::shape() const { return shape_; }
+inline DataType Tensor::type() const { return type_; }
+
+// Tensor operation APIs (unimplemented stubs)
+Tensor matmul(const Tensor &a, const Tensor &b);
+Tensor add(const Tensor &a, const Tensor &b);
+Tensor softmax(const Tensor &a, int axis);
+Tensor layer_norm(const Tensor &input, const Tensor &gamma, const Tensor &beta);
+Tensor embedding_lookup(const Tensor &table, const Tensor &indices);
+Tensor concat(const std::vector<Tensor> &inputs, int axis);
+
+} // namespace tensor
+
+#endif // TENSOR_OPS_H


### PR DESCRIPTION
## Summary
- design tensor API header with common ops
- design minimal Llama model API to consume tensor ops
- add an example showing how a Llama inference routine could use the API

## Testing
- `g++ -std=c++17 -Iinclude examples/axpy_example.cpp -o axpy_example`
- `./axpy_example | head -n 5`
- `g++ -std=c++17 -Iinclude -c examples/llama_example.cpp`


------
https://chatgpt.com/codex/tasks/task_e_6856d57dad208326b7b2d76c3a7b8d73