### PR TITLE
Add CPU reference Llama API

### DIFF
--- a/include/tensor_ops.h
+++ b/include/tensor_ops.h
@@ -2,6 +2,7 @@
 #define TENSOR_OPS_H
 
 #include <cstddef>
+#include <cstdint>
 #include <vector>
 
 namespace tensor {
@@ -9,6 +10,7 @@ namespace tensor {
 enum class DataType {
     F32,
     F16,
+    BF16,
     I32,
 };
 
@@ -19,17 +21,51 @@ public:
 
     const std::vector<std::size_t> &shape() const;
     DataType type() const;
+    std::size_t numel() const;
+    std::size_t elem_size() const;
+
+    template <typename T> T *data();
+    template <typename T> const T *data() const;
 
 private:
     std::vector<std::size_t> shape_;
     DataType type_{DataType::F32};
+    std::vector<unsigned char> buffer_;
 };
 
 inline Tensor::Tensor(const std::vector<std::size_t> &shape, DataType type)
-    : shape_(shape), type_(type) {}
+    : shape_(shape), type_(type) {
+    buffer_.resize(numel() * elem_size());
+}
 
 inline const std::vector<std::size_t> &Tensor::shape() const { return shape_; }
 inline DataType Tensor::type() const { return type_; }
+inline std::size_t Tensor::numel() const {
+    std::size_t n = 1;
+    for (std::size_t d : shape_)
+        n *= d;
+    return n;
+}
+inline std::size_t Tensor::elem_size() const {
+    switch (type_) {
+    case DataType::F32:
+        return sizeof(float);
+    case DataType::F16:
+        return sizeof(_Float16);
+    case DataType::BF16:
+        return sizeof(__bf16);
+    case DataType::I32:
+        return sizeof(int32_t);
+    }
+    return sizeof(float);
+}
+
+template <typename T> inline T *Tensor::data() {
+    return reinterpret_cast<T *>(buffer_.data());
+}
+template <typename T> inline const T *Tensor::data() const {
+    return reinterpret_cast<const T *>(buffer_.data());
+}
 
 // Tensor operation APIs (unimplemented stubs)
 Tensor matmul(const Tensor &a, const Tensor &b);

--- a/scripts/run_llama_test.sh
+++ b/scripts/run_llama_test.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+g++ -std=c++20 -Iinclude examples/llama_example.cpp \
+    src/tensor_ops.cpp src/llama_api.cpp -o llama_example
+./llama_example > llama_output.txt
+
+echo "Llama example output:" 
+cat llama_output.txt

--- a/src/llama_api.cpp
+++ b/src/llama_api.cpp
@@ -1,0 +1,101 @@
+#include "llama_api.h"
+#include <random>
+#include <sstream>
+#include <unordered_map>
+
+using namespace llama;
+using namespace tensor;
+
+static std::unordered_map<std::string, int> word2id;
+static std::unordered_map<int, std::string> id2word;
+
+Model::Model(const ModelConfig &config) {
+    token_embedding = Tensor({(std::size_t)config.vocab_size,
+                              (std::size_t)config.hidden_size},
+                             DataType::F32);
+    output_weight = Tensor({(std::size_t)config.hidden_size,
+                            (std::size_t)config.vocab_size},
+                           DataType::F32);
+    layer_weights.resize(config.num_layers);
+    for (auto &w : layer_weights)
+        w = Tensor({(std::size_t)config.hidden_size,
+                    (std::size_t)config.hidden_size},
+                   DataType::F32);
+
+    std::mt19937 gen(42);
+    std::uniform_real_distribution<float> dist(-0.5f, 0.5f);
+    auto init = [&](Tensor &t) {
+        for (std::size_t i = 0; i < t.numel(); ++i)
+            t.data<float>()[i] = dist(gen);
+    };
+    init(token_embedding);
+    init(output_weight);
+    for (auto &w : layer_weights)
+        init(w);
+}
+
+std::vector<int> Tokenizer::encode(const std::string &text) const {
+    std::vector<int> tokens;
+    std::istringstream iss(text);
+    std::string word;
+    while (iss >> word) {
+        auto it = word2id.find(word);
+        if (it == word2id.end()) {
+            int id = word2id.size();
+            word2id[word] = id;
+            id2word[id] = word;
+            tokens.push_back(id);
+        } else {
+            tokens.push_back(it->second);
+        }
+    }
+    return tokens;
+}
+
+std::string Tokenizer::decode(const std::vector<int> &tokens) const {
+    std::ostringstream oss;
+    for (std::size_t i = 0; i < tokens.size(); ++i) {
+        auto it = id2word.find(tokens[i]);
+        if (it != id2word.end())
+            oss << (i ? " " : "") << it->second;
+        else
+            oss << (i ? " " : "") << "?";
+    }
+    return oss.str();
+}
+
+InferenceSession::InferenceSession(const Model &model) : model_(model) {}
+
+static int argmax(const Tensor &t) {
+    float maxv = -1e9f;
+    int idx = 0;
+    for (std::size_t i = 0; i < t.numel(); ++i) {
+        float v = t.data<const float>()[i];
+        if (v > maxv) {
+            maxv = v;
+            idx = i;
+        }
+    }
+    return idx;
+}
+
+std::vector<int> InferenceSession::generate(const std::vector<int> &prompt,
+                                            int max_tokens) {
+    std::vector<int> out_tokens = prompt;
+    for (int t = 0; t < max_tokens; ++t) {
+        int token = out_tokens.back();
+        Tensor idx_tensor({1}, DataType::I32);
+        idx_tensor.data<int32_t>()[0] = token;
+        Tensor hidden = embedding_lookup(model_.token_embedding, idx_tensor);
+        for (const Tensor &w : model_.layer_weights) {
+            hidden = matmul(hidden, w);
+            hidden = softmax(hidden, 1);
+        }
+        Tensor logits = matmul(hidden, model_.output_weight);
+        logits = softmax(logits, 1);
+        int next = argmax(logits);
+        out_tokens.push_back(next);
+    }
+    return out_tokens;
+}
+

--- a/src/tensor_ops.cpp
+++ b/src/tensor_ops.cpp
@@ -1,0 +1,190 @@
+#include "tensor_ops.h"
+#include <stdexcept>
+#include <cmath>
+#include <algorithm>
+
+using namespace tensor;
+
+static float get_value(const Tensor &t, std::size_t idx) {
+    switch (t.type()) {
+    case DataType::F32:
+        return t.data<const float>()[idx];
+    case DataType::F16:
+        return static_cast<float>(t.data<const _Float16>()[idx]);
+    case DataType::BF16:
+        return static_cast<float>(t.data<const __bf16>()[idx]);
+    case DataType::I32:
+        return static_cast<float>(t.data<const int32_t>()[idx]);
+    }
+    return 0.f;
+}
+
+static void set_value(Tensor &t, std::size_t idx, float v) {
+    switch (t.type()) {
+    case DataType::F32:
+        t.data<float>()[idx] = v;
+        break;
+    case DataType::F16:
+        t.data<_Float16>()[idx] = (_Float16)v;
+        break;
+    case DataType::BF16:
+        t.data<__bf16>()[idx] = (__bf16)v;
+        break;
+    case DataType::I32:
+        t.data<int32_t>()[idx] = static_cast<int32_t>(v);
+        break;
+    }
+}
+
+Tensor tensor::matmul(const Tensor &a, const Tensor &b) {
+    if (a.shape().size() != 2 || b.shape().size() != 2)
+        throw std::runtime_error("matmul requires 2D tensors");
+    std::size_t m = a.shape()[0];
+    std::size_t k = a.shape()[1];
+    if (b.shape()[0] != k)
+        throw std::runtime_error("matmul shape mismatch");
+    std::size_t n = b.shape()[1];
+    Tensor out({m, n}, DataType::F32);
+    for (std::size_t i = 0; i < m; ++i) {
+        for (std::size_t j = 0; j < n; ++j) {
+            float sum = 0.f;
+            for (std::size_t p = 0; p < k; ++p) {
+                sum += get_value(a, i * k + p) * get_value(b, p * n + j);
+            }
+            set_value(out, i * n + j, sum);
+        }
+    }
+    return out;
+}
+
+Tensor tensor::add(const Tensor &a, const Tensor &b) {
+    if (a.shape() != b.shape())
+        throw std::runtime_error("add shape mismatch");
+    Tensor out(a.shape(), DataType::F32);
+    std::size_t n = a.numel();
+    for (std::size_t i = 0; i < n; ++i)
+        set_value(out, i, get_value(a, i) + get_value(b, i));
+    return out;
+}
+
+Tensor tensor::softmax(const Tensor &a, int axis) {
+    if (a.shape().size() != 2)
+        throw std::runtime_error("softmax only supports 2D");
+    std::size_t rows = a.shape()[0];
+    std::size_t cols = a.shape()[1];
+    Tensor out(a.shape(), DataType::F32);
+    if (axis == 0) {
+        for (std::size_t j = 0; j < cols; ++j) {
+            float maxv = -1e9;
+            for (std::size_t i = 0; i < rows; ++i)
+                maxv = std::max(maxv, get_value(a, i * cols + j));
+            float sum = 0.f;
+            for (std::size_t i = 0; i < rows; ++i) {
+                float e = std::exp(get_value(a, i * cols + j) - maxv);
+                sum += e;
+                set_value(out, i * cols + j, e);
+            }
+            for (std::size_t i = 0; i < rows; ++i) {
+                float val = get_value(out, i * cols + j) / sum;
+                set_value(out, i * cols + j, val);
+            }
+        }
+    } else {
+        for (std::size_t i = 0; i < rows; ++i) {
+            float maxv = -1e9;
+            for (std::size_t j = 0; j < cols; ++j)
+                maxv = std::max(maxv, get_value(a, i * cols + j));
+            float sum = 0.f;
+            for (std::size_t j = 0; j < cols; ++j) {
+                float e = std::exp(get_value(a, i * cols + j) - maxv);
+                sum += e;
+                set_value(out, i * cols + j, e);
+            }
+            for (std::size_t j = 0; j < cols; ++j) {
+                float val = get_value(out, i * cols + j) / sum;
+                set_value(out, i * cols + j, val);
+            }
+        }
+    }
+    return out;
+}
+
+Tensor tensor::layer_norm(const Tensor &input, const Tensor &gamma, const Tensor &beta) {
+    if (input.shape() != gamma.shape() || input.shape() != beta.shape())
+        throw std::runtime_error("layer_norm shape mismatch");
+    Tensor out(input.shape(), DataType::F32);
+    std::size_t n = input.numel();
+    float mean = 0.f;
+    for (std::size_t i = 0; i < n; ++i)
+        mean += get_value(input, i);
+    mean /= n;
+    float var = 0.f;
+    for (std::size_t i = 0; i < n; ++i) {
+        float diff = get_value(input, i) - mean;
+        var += diff * diff;
+    }
+    var /= n;
+    float inv_std = 1.0f / std::sqrt(var + 1e-5f);
+    for (std::size_t i = 0; i < n; ++i) {
+        float norm = (get_value(input, i) - mean) * inv_std;
+        float val = norm * get_value(gamma, i) + get_value(beta, i);
+        set_value(out, i, val);
+    }
+    return out;
+}
+
+Tensor tensor::embedding_lookup(const Tensor &table, const Tensor &indices) {
+    if (table.shape().size() != 2 || indices.shape().size() != 1)
+        throw std::runtime_error("embedding_lookup shape");
+    std::size_t vocab = table.shape()[0];
+    std::size_t dim = table.shape()[1];
+    std::size_t count = indices.shape()[0];
+    Tensor out({count, dim}, DataType::F32);
+    for (std::size_t i = 0; i < count; ++i) {
+        int idx = static_cast<int>(get_value(indices, i));
+        if (idx < 0 || static_cast<std::size_t>(idx) >= vocab)
+            throw std::runtime_error("embedding index out of range");
+        for (std::size_t j = 0; j < dim; ++j) {
+            float v = get_value(table, idx * dim + j);
+            set_value(out, i * dim + j, v);
+        }
+    }
+    return out;
+}
+
+Tensor tensor::concat(const std::vector<Tensor> &inputs, int axis) {
+    if (inputs.empty())
+        throw std::runtime_error("concat empty");
+    auto shape = inputs[0].shape();
+    std::size_t rank = shape.size();
+    for (const auto &t : inputs)
+        if (t.shape().size() != rank)
+            throw std::runtime_error("concat rank mismatch");
+    std::vector<std::size_t> out_shape = shape;
+    for (std::size_t i = 1; i < inputs.size(); ++i) {
+        for (std::size_t d = 0; d < rank; ++d) {
+            if (d == static_cast<std::size_t>(axis))
+                out_shape[d] += inputs[i].shape()[d];
+            else if (inputs[i].shape()[d] != shape[d])
+                throw std::runtime_error("concat shape mismatch");
+        }
+    }
+    Tensor out(out_shape, DataType::F32);
+    std::size_t inner = 1;
+    for (std::size_t d = axis + 1; d < rank; ++d)
+        inner *= shape[d];
+    std::size_t outer = 1;
+    for (std::size_t d = 0; d < static_cast<std::size_t>(axis); ++d)
+        outer *= shape[d];
+    std::size_t offset = 0;
+    for (std::size_t i = 0; i < outer; ++i) {
+        for (const auto &t : inputs) {
+            std::size_t len = t.shape()[axis] * inner;
+            for (std::size_t j = 0; j < len; ++j) {
+                set_value(out, offset++, get_value(t, i * len + j));
+            }
+        }
+    }
+    return out;
+}
+


### PR DESCRIPTION
## Summary
- implement CPU tensor ops with fp16/bf16 support
- add simple Llama model/tokenizer/session implementation
- provide test script compiling and running example

## Testing
- `scripts/run_llama_test.sh`


------
https://chatgpt.com/codex/tasks/task_e_6856dedb54c883268acd6d7b1264c4f2